### PR TITLE
feat: addmost_tackles method

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -235,4 +235,21 @@ class StatTracker
     top_team = @teams.find {|team| team.id == top_team_id }
     top_team.team_name
   end
+
+  def most_tackles(season)
+    season_data = find_season(season)
+    team_tackles = Hash.new(0)
+
+    season_data.game_teams.each do |game_team|
+      team_id = game_team.team_id
+      tackles = game_team.tackles
+
+      team_tackles[team_id] += tackles
+    end
+
+    team_id_with_most_tackles = team_tackles.max_by { |_, tackles| tackles }[0]
+    team_with_most_tackles = @teams.find { |team| team.id == team_id_with_most_tackles }
+
+    return team_with_most_tackles.team_name
+  end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -101,9 +101,9 @@ RSpec.describe StatTracker do
     expect(@stat_tracker.least_accurate_team("20122013")).to eq("Sporting Kansas City")
   end
 
-  xit "has a team with most tackles" do
+  it "has a team with most tackles" do
     # Name of the Team with the most tackles in the season	
-    expect(@stat_tracker.most_tackles("20122013")).to eq("")
+    expect(@stat_tracker.most_tackles("20122013")).to eq("FC Dallas")
   end
 
   xit "has a team with fewest tackles" do


### PR DESCRIPTION
Add most tackles method

started by using the find_season method in order to track data for a given season
created a new hash for the team tackles which will store the total number of tackles er team
Use .each to iterate over each team_id to find desired data which is tackles
Then l added code that increments the value in the team_tackles hash associated with the team_id by the number of tackles. 
The team_id serves as the key in the hash.
use max_by method to find team_id with most tackles
use the find method to find the team stored within the @teams variable, then compared  the team id with the team with most tackles to make sure they are one and the same
then return team name with most tackles