### PR TITLE
feat: add fewest tackles method

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -257,4 +257,21 @@ class StatTracker
 
     return team_with_most_tackles.team_name
   end
+
+  def fewest_tackles(season)
+    season_data = find_season(season)
+    team_tackles = Hash.new(0)
+  
+    season_data.game_teams.each do |game_team|
+      team_id = game_team.team_id
+      tackles = game_team.tackles
+  
+      team_tackles[team_id] += tackles
+    end
+  
+    team_id_with_fewest_tackles = team_tackles.min_by { |_, tackles| tackles }[0]
+    team_with_fewest_tackles = @teams.find { |team| team.id == team_id_with_fewest_tackles }
+  
+    team_with_fewest_tackles.team_name
+  end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe StatTracker do
     expect(@stat_tracker.most_tackles("20122013")).to eq("FC Dallas")
   end
 
-  xit "has a team with fewest tackles" do
+  it "has a team with fewest tackles" do
     #Name of the Team with the fewest tackles in the season	
-    expect(@stat_tracker.fewest_tackles("20122013")).to eq("")
+    expect(@stat_tracker.fewest_tackles("20122013")).to eq("Sporting Kansas City")
   end
 end


### PR DESCRIPTION
Pretty much identical to the most_tackles method,
just used min_by in order to find the team with fewest tackles.

Unskipped the test.