### PR TITLE
Refactor ag

### DIFF
--- a/lib/game_teams.rb
+++ b/lib/game_teams.rb
@@ -18,8 +18,4 @@ class GameTeam
     @shots = game_team_data[:shots].to_i
     @tackles = game_team_data[:tackles].to_i
   end
-
-  def accuracy
-    @goals.to_f / @shots
-  end
 end

--- a/lib/season.rb
+++ b/lib/season.rb
@@ -84,9 +84,10 @@ class Season
     team_games = @game_teams.group_by { |game_team| game_team.team_id }
     team_accuracy = {}
     team_games.each do |team_id, games|
-      accuracy_by_game = games.map { |game| game.accuracy }
-      overall_accuracy = accuracy_by_game.sum.to_f / accuracy_by_game.length
-      team_accuracy[team_id] = overall_accuracy
+      shots = games.map { |game| game.shots }
+      goals = games.map { |game| game.goals }
+      accuracy = goals.sum / shots.sum.to_f
+      team_accuracy[team_id] = accuracy
     end
     @team_accuracy = team_accuracy
   end

--- a/lib/season.rb
+++ b/lib/season.rb
@@ -6,7 +6,6 @@ class Season
               :game_teams,
               :game_ids,
               :team_ids,
-              :teams,
               :team_tackles,
               :team_accuracy
 
@@ -16,7 +15,6 @@ class Season
     @game_ids = generate_game_ids
     @game_teams = generate_game_teams(game_team_file)
     @team_ids = generate_team_ids
-    @teams = generate_teams(team_data)
     @team_tackles = generate_tackle_data
     @team_accuracy = generate_accuracy_data
   end
@@ -57,17 +55,6 @@ class Season
       team_ids << game.team_id
     end
     @team_ids = team_ids.uniq
-  end
-
-  def generate_teams(team_data)
-    teams = []
-    team_lines = CSV.open team_data, headers: true, header_converters: :symbol
-    team_lines.each do |line|
-      if !@team_ids.include?(line[:team_id])
-        teams << Team.new(line)
-      end
-    end
-    @teams = teams
   end
 
   def generate_tackle_data

--- a/spec/game_teams_spec.rb
+++ b/spec/game_teams_spec.rb
@@ -33,8 +33,4 @@ RSpec.describe GameTeam do
     expect(@game_team_1.shots).to eq(8)
     expect(@game_team_1.tackles).to eq(44)
   end
-
-  it "can calculate a ratio of shots to goals" do
-    expect(@game_team_1.accuracy).to eq(0.25)
-  end
 end

--- a/spec/season_spec.rb
+++ b/spec/season_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe Season do
     expect(@season.team_ids).to eq(["3", "6", "5"])
   end
 
-  it "has teams" do
-    expect(@season.teams).to be_an(Array)
-    expect(@season.teams.sample).to be_a(Team)
-    expect(@season.teams.first.team_name).to eq("Atlanta United")
-  end 
-
   it "has tackle data by team id" do
     expected = {
       "3" => 179,
@@ -60,9 +54,9 @@ RSpec.describe Season do
   it "has team accuracy data by team id" do
     expect(@season.team_accuracy).to be_a(Hash)
     expected = {
-      "3" => 0.20634920634920634,
-      "5" => 0.060897435897435896,
-      "6" => 0.32407407407407407
+      "3"=>0.21052631578947367, 
+      "5"=>0.0625, 
+      "6"=>0.3157894736842105
     }
     expect(@season.team_accuracy).to eq(expected)
   end


### PR DESCRIPTION
Fix issue causing spec harness most_accurate_team test to fail:

Changed accuracy calculation in Season to get an overall season accuracy percentage, as opposed to averaging the accuracy from each individual game

Removed methods that were ultimately not needed to pass all StatTracker methods, and their tests